### PR TITLE
fix get_i18n for some missing i18n

### DIFF
--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -3,11 +3,12 @@ import re
 
 
 def get_i18n(i18n_response: str):
-    reg_script = '{name}\("{id}",({fn}|"{any}")\)'.format(
+    reg_script = '{name}\("{id}",({fn}|{quote}{any}{quote})\)'.format(
+        quote="[\"']",
         name="([a-z])",
         id="([a-z0-9]{8})",
         any="([\s\S]*?)",
-        fn="\(function\(e\){return([\s\S]*?)}\)",
+        fn="\(function\([aent]\){return([\s\S]*?)}\)",
     )
 
     res_1 = {
@@ -45,7 +46,7 @@ def replace_ver(script):
             reg="(\"|')?",
             join="(\+)?",
             name="([a-z])",
-            ins="(e|this\.props)",
+            ins="([aent]|this\.props)",
             placeholder="([A-Za-z0-9_]+)",
             any="([\s\S]*?)",
         ),
@@ -57,7 +58,7 @@ def replace_ver(script):
             reg="(\"|')?",
             join="(\+)?",
             name="([a-z])",
-            ins="(e|this\.props)",
+            ins="([aent]|this\.props)",
             placeholder="([A-Za-z0-9_]+)",
             any="([\s\S]*?)",
         ),
@@ -69,7 +70,7 @@ def replace_ver(script):
             reg="(\"|')?",
             join="(\+)?",
             name="([a-z])",
-            ins="(e|this\.props)",
+            ins="([aent]|this\.props)",
             placeholder="([A-Za-z0-9_]+)",
             any="([\s\S]*?)",
         ),
@@ -81,7 +82,7 @@ def replace_ver(script):
         "{reg}{join}{ins}\.{placeholder}{join}{reg}".format(
             reg="(\"|')?",
             join="(\+)?",
-            ins="(e|this\.props)",
+            ins="([aent]|this\.props)",
             placeholder="([A-Za-z0-9_]+)",
         ),
         r"\1\2{double_quotation}{\4}{double_quotation}\5\6",


### PR DESCRIPTION
related to #274 (, https://github.com/kaonasi-biwa/Twitter-UI-Customizer/pull/214)

### line 6-7
Allow single quotations

[el](https://abs.twimg.com/responsive-web/client-web/i18n/el.2eae710a.js) -> search `"d636ebc6"`
el or [he](https://abs.twimg.com/responsive-web/client-web/i18n/he.b70d05ba.js) -> search `"d7b8ebaa"`

### line 10, 48, 60, 72, 84
Argument name variations of `function(e)`

`function(a)` <- [fi](https://abs.twimg.com/responsive-web/client-web/i18n/fi.1c81817a.js), fil, ha, hr, id, ms
`function(n)` <- [vi](https://abs.twimg.com/responsive-web/client-web/i18n/vi.2cf3c2ba.js)
`function(t)` <- [en-xx](https://abs.twimg.com/responsive-web/client-web/i18n/en-xx.0e4a7eba.js)

`[a-z]`にしても(↓のようなことがなければ)問題はなさそうに見えますが、どうしましょうか?

### Broken by changes
[sv](https://abs.twimg.com/responsive-web/client-web/i18n/sv.0d7c8b4a.js)
`{key:"cbc4f32d",get:function(){return["Detta omfattar andra medier som har märkts som känsliga, t.ex. medier från konton som i sina "," har angett att deras medier är känsliga."]}}`
↓
`Detta omfattar andra medier som har märkts som känsliga{0} har angett att deras medier är känsliga.`

`t.ex.`のところに引っかかってしまったか
eだけでも起こりうるものではある

他にもあるかも(ありそう)

### other
大した問題ではないですが、windows上で`py ./generator.py`するとすべてCRLFで生成されます

base(merge先)はmasterじゃなくてdevelopの方が良いですか?
