### PR TITLE
fix i18n format

### DIFF
--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -8,7 +8,7 @@ def get_i18n(i18n_response: str):
         name=r"([a-z])",
         id=r"([a-z0-9]{8})",
         any=r"([\s\S]*?)",
-        fn=r"\(function\([aent]\){return([\s\S]*?)}\)",
+        fn=r"\(function\([aeint]\){return([\s\S]*?)}\)",
     )
 
     res_1 = {
@@ -46,7 +46,7 @@ def replace_ver(script: str):
             reg=r"(\"|')?",
             join=r"(\+)?",
             name=r"([a-z])",
-            ins=r"([aent]|this\.props)",
+            ins=r"([aeint]|this\.props)",
             placeholder=r"([A-Za-z0-9_]+)",
             any=r"([^\(\)]*?)",
             notname=r"([^\+,][\s\S]|[\+,]?[\"'])",
@@ -59,7 +59,7 @@ def replace_ver(script: str):
             reg=r"(\"|')?",
             join=r"(\+)?",
             name=r"([a-z])",
-            ins=r"([aent]|this\.props)",
+            ins=r"([aeint]|this\.props)",
             placeholder=r"([A-Za-z0-9_]+)",
             any=r"([\s\S]*?)",
         ),
@@ -71,7 +71,7 @@ def replace_ver(script: str):
         r"{reg}{join}{ins}\.{placeholder}(?={join}{reg})".format(
             reg=r"(\"|')?",
             join=r"(\+|^|$|,)",
-            ins=r"([aent]|this\.props)",
+            ins=r"([aeint]|this\.props)",
             placeholder=r"([A-Za-z0-9_]+)",
         ),
         r"\1\2{double_quotation}{\4}{double_quotation}",

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -3,12 +3,12 @@ import re
 
 
 def get_i18n(i18n_response: str):
-    reg_script = '{name}\("{id}",({fn}|{quote}{any}{quote})\)[,;}}]'.format(
-        quote="[\"']",
-        name="([a-z])",
-        id="([a-z0-9]{8})",
-        any="([\s\S]*?)",
-        fn="\(function\([aent]\){return([\s\S]*?)}\)",
+    reg_script = r'{name}\("{id}",({fn}|{quote}{any}{quote})\)[,;}}]'.format(
+        quote=r"[\"']",
+        name=r"([a-z])",
+        id=r"([a-z0-9]{8})",
+        any=r"([\s\S]*?)",
+        fn=r"\(function\([aent]\){return([\s\S]*?)}\)",
     )
 
     res_1 = {
@@ -16,9 +16,9 @@ def get_i18n(i18n_response: str):
         for script in re.findall(reg_script, i18n_response)
     }
 
-    reg_script = '{{key:"{id}",get:{fn}}}'.format(
-        id="([a-z0-9]{8})",
-        fn="function\(\){return([\s\S]*?)}",
+    reg_script = r'{{key:"{id}",get:{fn}}}'.format(
+        id=r"([a-z0-9]{8})",
+        fn=r"function\(\){return([\s\S]*?)}",
     )
 
     res_2 = {
@@ -34,60 +34,60 @@ def get_i18n(i18n_response: str):
 
 def replace_ver(script: str):
     a = re.sub(
-        "{name}\.createElement\({any},([^,]*?)\)".format(
-            name="([a-z])",
-            any="([\s\S]*?)",
+        r"{name}\.createElement\({any},([^,]*?)\)".format(
+            name=r"([a-z])",
+            any=r"([\s\S]*?)",
         ),
         r"\3",
         script,
     )
     b = re.sub(
-        "{reg}{join}{name}\({ins}\.{placeholder},{any}(({notname}\({any}\){any})+?)\){join}{reg}".format(
-            reg="(\"|')?",
-            join="(\+)?",
-            name="([a-z])",
-            ins="([aent]|this\.props)",
-            placeholder="([A-Za-z0-9_]+)",
-            any="([^\(\)]*?)",
-            notname="([^\+,][\s\S]|[\+,]?[\"'])",
+        r"{reg}{join}{name}\({ins}\.{placeholder},{any}(({notname}\({any}\){any})+?)\){join}{reg}".format(
+            reg=r"(\"|')?",
+            join=r"(\+)?",
+            name=r"([a-z])",
+            ins=r"([aent]|this\.props)",
+            placeholder=r"([A-Za-z0-9_]+)",
+            any=r"([^\(\)]*?)",
+            notname=r"([^\+,][\s\S]|[\+,]?[\"'])",
         ),
         r"\1\2'('+\4.\5,\6\7+')'\12\13",
         a,
     )
     c = re.sub(
-        "{reg}{join}{name}\({ins}\.{placeholder},{any}\){join}{reg}".format(
-            reg="(\"|')?",
-            join="(\+)?",
-            name="([a-z])",
-            ins="([aent]|this\.props)",
-            placeholder="([A-Za-z0-9_]+)",
-            any="([\s\S]*?)",
+        r"{reg}{join}{name}\({ins}\.{placeholder},{any}\){join}{reg}".format(
+            reg=r"(\"|')?",
+            join=r"(\+)?",
+            name=r"([a-z])",
+            ins=r"([aent]|this\.props)",
+            placeholder=r"([A-Za-z0-9_]+)",
+            any=r"([\s\S]*?)",
         ),
         r"\1\2'('+\4.\5,\6+')'\7\8",
         b,
     )
 
     e = re.sub(
-        "{reg}{join}{ins}\.{placeholder}(?={join}{reg})".format(
-            reg="(\"|')?",
-            join="(\+|^|$|,)",
-            ins="([aent]|this\.props)",
-            placeholder="([A-Za-z0-9_]+)",
+        r"{reg}{join}{ins}\.{placeholder}(?={join}{reg})".format(
+            reg=r"(\"|')?",
+            join=r"(\+|^|$|,)",
+            ins=r"([aent]|this\.props)",
+            placeholder=r"([A-Za-z0-9_]+)",
         ),
         r"\1\2{double_quotation}{\4}{double_quotation}",
         c,
     ).replace("{double_quotation}", '"')
     d = re.sub(
-        "{reg},{reg}(?!$)".format(
-            reg="(\"|')",
+        r"{reg},{reg}(?!$)".format(
+            reg=r"(\"|')",
         ),
         r"\1+','+\2",
         e,
     )
     output = re.sub(
-        "('{any}'|\"{any}\")\+(?={reg})".format(
-            reg="(\"|')",
-            any="([\s\S]*?)",
+        r"('{any}'|\"{any}\")\+(?={reg})".format(
+            reg=r"(\"|')",
+            any=r"([\s\S]*?)",
         ),
         r"\1,",
         d,

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -8,7 +8,7 @@ def get_i18n(i18n_response: str):
         name=r"([a-z])",
         id=r"([a-z0-9]{8})",
         any=r"([\s\S]*?)",
-        fn=r"\(function\([aeint]\){return([\s\S]*?)}\)",
+        fn=r"\(function\([a-z]\){return([\s\S]*?)}\)",
     )
 
     res_1 = {
@@ -46,7 +46,7 @@ def replace_ver(script: str):
             reg=r"(\"|')?",
             join=r"(\+)?",
             name=r"([a-z])",
-            ins=r"([aeint]|this\.props)",
+            ins=r"([a-z]|this\.props)",
             placeholder=r"([A-Za-z0-9_]+)",
             any=r"([^\(\)]*?)",
             notname=r"([^\+,][\s\S]|[\+,]?[\"'])",
@@ -59,7 +59,7 @@ def replace_ver(script: str):
             reg=r"(\"|')?",
             join=r"(\+)?",
             name=r"([a-z])",
-            ins=r"([aeint]|this\.props)",
+            ins=r"([a-z]|this\.props)",
             placeholder=r"([A-Za-z0-9_]+)",
             any=r"([\s\S]*?)",
         ),
@@ -71,7 +71,7 @@ def replace_ver(script: str):
         r"{reg}{join}{ins}\.{placeholder}(?={join}{reg})".format(
             reg=r"(\"|')?",
             join=r"(\+|^|$|,)",
-            ins=r"([aeint]|this\.props)",
+            ins=r"([a-z]|this\.props)",
             placeholder=r"([A-Za-z0-9_]+)",
         ),
         r"\1\2{double_quotation}{\4}{double_quotation}",

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -34,11 +34,11 @@ def get_i18n(i18n_response: str):
 
 def replace_ver(script):
     a = re.sub(
-        "{name}\.createElement\({any}\)".format(
+        "{name}\.createElement\({any},([^,]*?)\)".format(
             name="([a-z])",
             any="([\s\S]*?)",
         ),
-        "",
+        r"\3",
         script,
     )
     b = re.sub(

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -78,7 +78,7 @@ def replace_ver(script):
         c,
     ).replace("{double_quotation}", '"')
     d = re.sub(
-        "{reg},{reg}".format(
+        "{reg},{reg}(?!$)".format(
             reg="(\"|')",
         ),
         r"\1+','+\2",

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -3,7 +3,7 @@ import re
 
 
 def get_i18n(i18n_response: str):
-    reg_script = '{name}\("{id}",({fn}|{quote}{any}{quote})\)'.format(
+    reg_script = '{name}\("{id}",({fn}|{quote}{any}{quote})\)[,;}}]'.format(
         quote="[\"']",
         name="([a-z])",
         id="([a-z0-9]{8})",

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -32,7 +32,7 @@ def get_i18n(i18n_response: str):
     return res_1 | res_2
 
 
-def replace_ver(script):
+def replace_ver(script: str):
     a = re.sub(
         "{name}\.createElement\({any},([^,]*?)\)".format(
             name="([a-z])",
@@ -107,14 +107,14 @@ def replace_ver(script):
     return [script]
 
 
-def i18n_format_1(script):
+def i18n_format_1(script: str):
     return "".join(replace_ver(script))
 
 
-def i18n_format_2(script):
-    data = [""]
-    quote = []
-    before = ""
+def i18n_format_2(script: str):
+    data: list[str] = [""]
+    quote: list[str] = []
+    before: str = ""
     for d in script.lstrip("[").rstrip("]"):
         if d == "\\":
             before += "\\"

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -41,6 +41,30 @@ def replace_ver(script):
         "",
         script,
     )
+    bbb = re.sub(
+        "{reg}{join}{name}\({ins}\.{placeholder},{any}\({any}\){any},{any},{any}\({any}\){any},{any}\({any}\){any}\){join}{reg}".format(
+            reg="(\"|')?",
+            join="(\+)?",
+            name="([a-z])",
+            ins="([aent]|this\.props)",
+            placeholder="([A-Za-z0-9_]+)",
+            any="([^\(\)]*?)",
+        ),
+        r"\1\2'('+\4.\5,\6(\7)\8,\9,\10(\11)\12,\13(\14)\15+')'\16\17",
+        a,
+    )
+    bb = re.sub(
+        "{reg}{join}{name}\({ins}\.{placeholder},{any}\({any}\){any},{any},{any}\({any}\){any}\){join}{reg}".format(
+            reg="(\"|')?",
+            join="(\+)?",
+            name="([a-z])",
+            ins="([aent]|this\.props)",
+            placeholder="([A-Za-z0-9_]+)",
+            any="([^\(\)]*?)",
+        ),
+        r"\1\2'('+\4.\5,\6(\7)\8,\9,\10(\11)\12+')'\13\14",
+        bbb,
+    )
     b = re.sub(
         "{reg}{join}{name}\({ins}\.{placeholder},{any},{any}\({any}\){any}\){join}{reg}".format(
             reg="(\"|')?",
@@ -48,24 +72,12 @@ def replace_ver(script):
             name="([a-z])",
             ins="([aent]|this\.props)",
             placeholder="([A-Za-z0-9_]+)",
-            any="([\s\S]*?)",
+            any="([^\(\)]*?)",
         ),
-        r"\1\2\4.\5+\6\10\11",
-        a,
+        r"\1\2'('+\4.\5,\6,\7(\8)\9+')'\10\11",
+        bb,
     )
     c = re.sub(
-        "{reg}{join}{name}\({ins}\.{placeholder},{any},{any}\){join}{reg}".format(
-            reg="(\"|')?",
-            join="(\+)?",
-            name="([a-z])",
-            ins="([aent]|this\.props)",
-            placeholder="([A-Za-z0-9_]+)",
-            any="([\s\S]*?)",
-        ),
-        r"\1\2\4.\5+\6\8\9",
-        b,
-    )
-    d = re.sub(
         "{reg}{join}{name}\({ins}\.{placeholder},{any}\){join}{reg}".format(
             reg="(\"|')?",
             join="(\+)?",
@@ -74,21 +86,28 @@ def replace_ver(script):
             placeholder="([A-Za-z0-9_]+)",
             any="([\s\S]*?)",
         ),
-        r"\1\2\4.\5+\6\7\8",
-        c,
+        r"\1\2'('+\4.\5,\6+')'\7\8",
+        b,
     )
 
     e = re.sub(
-        "{reg}{join}{ins}\.{placeholder}{join}{reg}".format(
+        "{reg}{join}{ins}\.{placeholder}(?={join}{reg})".format(
             reg="(\"|')?",
-            join="(\+)?",
+            join="(\+|^|$|,)",
             ins="([aent]|this\.props)",
             placeholder="([A-Za-z0-9_]+)",
         ),
-        r"\1\2{double_quotation}{\4}{double_quotation}\5\6",
-        d,
+        r"\1\2{double_quotation}{\4}{double_quotation}",
+        c,
     ).replace("{double_quotation}", '"')
-    output = e.replace("+", ",")
+    d = re.sub(
+        "{reg},{reg}".format(
+            reg="(\"|')",
+        ),
+        r"\1+','+\2",
+        e,
+    )
+    output = d.replace("+", ",")
     output = f"[{output}]"
     try:
         return ast.literal_eval(output)

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -41,41 +41,18 @@ def replace_ver(script):
         "",
         script,
     )
-    bbb = re.sub(
-        "{reg}{join}{name}\({ins}\.{placeholder},{any}\({any}\){any},{any},{any}\({any}\){any},{any}\({any}\){any}\){join}{reg}".format(
-            reg="(\"|')?",
-            join="(\+)?",
-            name="([a-z])",
-            ins="([aent]|this\.props)",
-            placeholder="([A-Za-z0-9_]+)",
-            any="([^\(\)]*?)",
-        ),
-        r"\1\2'('+\4.\5,\6(\7)\8,\9,\10(\11)\12,\13(\14)\15+')'\16\17",
-        a,
-    )
-    bb = re.sub(
-        "{reg}{join}{name}\({ins}\.{placeholder},{any}\({any}\){any},{any},{any}\({any}\){any}\){join}{reg}".format(
-            reg="(\"|')?",
-            join="(\+)?",
-            name="([a-z])",
-            ins="([aent]|this\.props)",
-            placeholder="([A-Za-z0-9_]+)",
-            any="([^\(\)]*?)",
-        ),
-        r"\1\2'('+\4.\5,\6(\7)\8,\9,\10(\11)\12+')'\13\14",
-        bbb,
-    )
     b = re.sub(
-        "{reg}{join}{name}\({ins}\.{placeholder},{any},{any}\({any}\){any}\){join}{reg}".format(
+        "{reg}{join}{name}\({ins}\.{placeholder},{any}(({notname}\({any}\){any})+?)\){join}{reg}".format(
             reg="(\"|')?",
             join="(\+)?",
             name="([a-z])",
             ins="([aent]|this\.props)",
             placeholder="([A-Za-z0-9_]+)",
             any="([^\(\)]*?)",
+            notname="([^\+,][\s\S]|[\+,]?[\"'])",
         ),
-        r"\1\2'('+\4.\5,\6,\7(\8)\9+')'\10\11",
-        bb,
+        r"\1\2'('+\4.\5,\6\7+')'\12\13",
+        a,
     )
     c = re.sub(
         "{reg}{join}{name}\({ins}\.{placeholder},{any}\){join}{reg}".format(

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -154,7 +154,7 @@ def i18n_format_2(script):
                 quote.append("+")
         elif d == quote[-1]:
             quote.pop()
-        elif d in ["("]:
+        elif d in ["("] and quote[-1] == "+":
             quote.append(d.replace("(", ")"))
         data[-1] += d
 

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -92,6 +92,7 @@ def replace_ver(script):
         r"\1,",
         d,
     )
+    output = output.replace("\"+','+\"", '","')
     output = f"[{output}]"
     try:
         return ast.literal_eval(output)

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -107,7 +107,14 @@ def replace_ver(script):
         r"\1+','+\2",
         e,
     )
-    output = d.replace("+", ",")
+    output = re.sub(
+        "{reg}{any}{reg}\+(?={reg})".format(
+            reg="(\"|')",
+            any="([\s\S]*?)",
+        ),
+        r"\1\2\3,",
+        d,
+    )
     output = f"[{output}]"
     try:
         return ast.literal_eval(output)

--- a/lib/md_generator/i18n.py
+++ b/lib/md_generator/i18n.py
@@ -85,11 +85,11 @@ def replace_ver(script):
         e,
     )
     output = re.sub(
-        "{reg}{any}{reg}\+(?={reg})".format(
+        "('{any}'|\"{any}\")\+(?={reg})".format(
             reg="(\"|')",
             any="([\s\S]*?)",
         ),
-        r"\1\2\3,",
+        r"\1,",
         d,
     )
     output = f"[{output}]"


### PR DESCRIPTION
コンマ辺りの処理は粗削りですが、ほとんど(確認した限りでは全て)のケースをカバー出来ました

#277 以前のように、`r(e.count,"","s")`のようなものがあれば`({count},,s)`のようになるようになっています